### PR TITLE
[BUG FIX] Fixing Bug with Docker MySQL .env & Port

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -19,9 +19,9 @@ Before you begin, ensure you have Docker Desktop installed on your machine. Foll
     - Inside the `db` folder, create a file named `.env`.
     - Add the following environment variables to the `.env` file:
     ```plaintext
-    USER_PWD=pwd12345
-    USER_NAME=exampleUser
-    ROOT_PWD=rootpassword
+    MYSQL_PASSWORD=pwd12345
+    MYSQL_USER=exampleUser
+    MYSQL_ROOT_PASSWORD=rootpassword
     ```
 
 2. **Run the Server:**

--- a/db/README.md
+++ b/db/README.md
@@ -1,6 +1,6 @@
 # MySQL Database
 
-This is MySQL database used to store manga information that was previously stored in .csv files. The database is running on port 3306.
+This is MySQL database used to store manga information that was previously stored in .csv files. The database is running on port 4040.
 
 ## Setup Instructions
 
@@ -27,7 +27,7 @@ Before you begin, ensure you have Docker Desktop installed on your machine. Foll
 2. **Run the Server:**
     - Open a terminal and navigate to the root directory of this repository.
     - Run the following command to start the MySQL server using Docker Compose:
-    - This will have the server running on `localhost:3306`
+    - This will have the server running on `localhost:4040`
     ```sh
     docker-compose --env-file path/to/.env up
     ```

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       # Password for root access
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     ports:
-      - '3306:3306'
+      - '4040:3306'
     networks:
       - backnet
     volumes:

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -11,10 +11,10 @@ services:
     environment:
       #! NOTE: Have to create db name here for user to have access to db
       MYSQL_DATABASE: manga_db
-      MYSQL_USER: ${USER_PWD}
-      MYSQL_PASSWORD: ${USER_NAME}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       # Password for root access
-      MYSQL_ROOT_PASSWORD: ${ROOT_PWD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     ports:
       - '3306:3306'
     networks:


### PR DESCRIPTION
## Overview
This pull request addresses an issue related to Docker MySQL username and password configuration. The issue was causing authentication problems when trying to connect to the MySQL database from external sources. Also changing port to be on `4040` instead of `3306`, since we are having port conflicting port issue.

## Changes Made
* Updated the Docker configuration to correctly set the MySQL username and password.
* Update .env naming to be easier to understand and resolve future issues
* Verified and tested the connection to ensure the issue is resolved.
* Port is now on `4040`

## Important
Please ensure to update your local environment variables accordingly after merging this pull request to avoid any connection issues.